### PR TITLE
[Briefer]: Add Init Container for File Permissions

### DIFF
--- a/charts/briefer/Chart.yaml
+++ b/charts/briefer/Chart.yaml
@@ -3,5 +3,5 @@ name: briefer
 home: https://github.com/briefercloud/briefer/tree/main/helm
 description: A chart for installing Briefer and all of it's components.
 
-version: 0.1.2
-appVersion: 0.0.26
+version: 0.1.3
+appVersion: 0.0.88

--- a/charts/briefer/README.md
+++ b/charts/briefer/README.md
@@ -2,7 +2,7 @@
 
 A chart for installing Briefer and all of it's components.
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: 0.0.26](https://img.shields.io/badge/AppVersion-0.0.26-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: 0.0.88](https://img.shields.io/badge/AppVersion-0.0.88-informational?style=flat-square)
 
 This repository contains a Helm chart which can be used to deploy [Briefer] to your Kubernetes cluster.
 

--- a/charts/briefer/templates/jupyter.yaml
+++ b/charts/briefer/templates/jupyter.yaml
@@ -36,6 +36,17 @@ spec:
         role: jupyter
     spec:
       serviceAccount: {{ include "helm.serviceAccountName" . }}
+      initContainers:
+        - name: permissions
+          image: briefercloud/briefer-jupyter:v{{ default .Chart.AppVersion .Values.jupyter.version }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - mkdir -p /data/.local/share/jupyter/runtime && chown -R jupyteruser:$(id -g) /data && chmod -R 775 /data
+          volumeMounts:
+            - name: {{ include "helm.name" . }}-jupyter
+              mountPath: /data
       containers:
         - name: jupyter
           image: briefercloud/briefer-jupyter:v{{ default .Chart.AppVersion .Values.jupyter.version }}


### PR DESCRIPTION
The jupyter pod runs an image that does not run as root. STS volumes are implicitly set for the root user. In order to boot, we need to chown the directory so it's owned by `jupyteruser`.